### PR TITLE
Add encapsulated-plugin compatibility for Zen Cart 2.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ It can be downloaded from the Zen Cart Plugins repository here: https://www.zen-
 
 Zen-Cart Versions Supported
 --------------
-1.5.8[a], 2.0.x, 2.1.0
+1.5.8[a], 2.0.x, 2.1.0, 2.2.1
 
 Support thread
 --------------
@@ -98,6 +98,12 @@ Install:
 5. Go to ***Admin :: Configuration :: Sitemap XML*** and setup all parameters.
 6. Go to ***Admin :: Tools :: Sitemap XML*** (If error messages occur, change permissions on the XML files to 777).
 7. To have the site's sitemap files automatically update, you will need to set up a Cron job via your host's control panel.  Refer to the admin tool's tips for additional information.
+
+Encapsulated plugin note:
+--------------
+When packaged for use as a Zen Cart encapsulated plugin (`zc_plugins`), the module's admin and storefront processing now detect and load their sitemap-generator modules from either installation style.
+
+If you extract a package directly via cPanel or another hosting file manager, verify permissions before installation. Typical settings are directories `755`, files `644`, with the sitemap output directory writable by PHP.
 
 Upgrade:
 --------------

--- a/sitemapXML/YOUR_Admin/sitemapxml.php
+++ b/sitemapXML/YOUR_Admin/sitemapxml.php
@@ -186,7 +186,10 @@ if (!file_exists(DIR_FS_CATALOG . 'robots.txt')) {
                         <?= zen_draw_form('selectPlugins', FILENAME_SITEMAPXML, '', 'post', 'id="selectPlugins"') ?>
                             <?= zen_draw_hidden_field('action', 'select_plugins') ?>
 <?php
-$plugins_files = glob(DIR_FS_CATALOG_MODULES . 'pages/sitemapxml/sitemapxml_*.php');
+$plugins_files = glob(dirname(__DIR__) . '/includes/modules/pages/sitemapxml/sitemapxml_*.php');
+if (empty($plugins_files)) {
+    $plugins_files = glob(DIR_FS_CATALOG_MODULES . 'pages/sitemapxml/sitemapxml_*.php');
+}
 if (empty($plugins_files)) {
     $plugins_files = [];
 }

--- a/sitemapXML/includes/modules/pages/sitemapxml/header_php.php
+++ b/sitemapXML/includes/modules/pages/sitemapxml/header_php.php
@@ -24,9 +24,14 @@ set_time_limit(0);
 $zco_notifier->notify('NOTIFY_HEADER_START_SITEMAPXML');
 
 /**
- * load the site map class
+ * Load the site map class from either a classic installation or an encapsulated plugin.
  */
-require DIR_WS_CLASSES . 'sitemapxml.php';
+$plugin_local_class = dirname(__DIR__, 3) . '/classes/sitemapxml.php';
+if (file_exists($plugin_local_class)) {
+    require $plugin_local_class;
+} else {
+    require DIR_WS_CLASSES . 'sitemapxml.php';
+}
 
 /**
  * load language files
@@ -54,8 +59,13 @@ if (is_file($tpl_dir . '/gss.xsl')) {
     $sitemapXML->setStylesheet($tpl_dir . '/gss.xsl');
 }
 
-$SiteMapXMLmodules = [];
-$SiteMapXMLmodules = glob(DIR_WS_MODULES . 'pages/' . $current_page_base . '/sitemapxml_*.php');
+$SiteMapXMLmodules = glob(__DIR__ . '/sitemapxml_*.php');
+if (empty($SiteMapXMLmodules)) {
+    $SiteMapXMLmodules = glob(DIR_WS_MODULES . 'pages/' . $current_page_base . '/sitemapxml_*.php');
+}
+if (empty($SiteMapXMLmodules)) {
+    $SiteMapXMLmodules = [];
+}
 
 $pluginsFilesActive = explode(';', SITEMAPXML_PLUGINS);
 $temp = [];


### PR DESCRIPTION
This PR adds compatibility for using SitemapXML as an encapsulated plugin on Zen Cart 2.2.1 while retaining support for the classic installation layout.

Summary of changes:
- In storefront `header_php.php`, load `sitemapxml.php` from the plugin-local classes directory when present, falling back to the classic core path otherwise.
- In storefront `header_php.php`, discover `sitemapxml_*.php` generator modules from the plugin-local page directory first, then fall back to the classic core path.
- In `YOUR_Admin/sitemapxml.php`, discover the available sitemap generator modules from the plugin-local directory first, then fall back to the classic core path.
- Update the README to note Zen Cart 2.2.1 support and mention encapsulated-plugin usage and file-permission considerations.

Why:
- When packaged as an encapsulated plugin in `zc_plugins`, the current v4.0.5 code still looks for the sitemap class and generator modules in the classic core locations. That leaves the admin generator list empty and prevents sitemap generation.
- These changes allow the same codebase to work in both classic and encapsulated installation styles.

Validation:
- Tested with Zen Cart 2.2.1 in an encapsulated-plugin deployment.
- Verified that the admin page lists the sitemap generator modules correctly.
- Verified that sitemap generation works after installation and configuration.
- Ran PHP lint on the modified files.